### PR TITLE
2 stages dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.21 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o succint_exporter .
+
+FROM alpine:latest AS runner
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /app/succint_exporter /succint_exporter
+
+EXPOSE 9103
+
+CMD ["/succint_exporter"]


### PR DESCRIPTION
```
❯ docker run succint_exporter:latest
ts=2024-04-24T11:32:55.235Z caller=main.go:36 level=info msg="Starting succint_exporter" version="(version=, branch=, revision=e18bef624acca3580bccb41a73b46924e772e221-modified)"
ts=2024-04-24T11:32:55.235Z caller=main.go:37 level=info msg="Build context" context="(go=go1.21.9, platform=linux/amd64, user=, date=, tags=unknown)"
ts=2024-04-24T11:32:55.235Z caller=tls_config.go:313 level=info msg="Listening on" address=[::]:9103
ts=2024-04-24T11:32:55.235Z caller=tls_config.go:316 level=info msg="TLS is disabled." http2=false address=[::]:9103
```